### PR TITLE
Add bundle cache age and deploy brotli bundle

### DIFF
--- a/deploy/s3.js
+++ b/deploy/s3.js
@@ -28,7 +28,8 @@ const uploadToS3 = async (
   fileBody,
   fileType = "",
   encoding = "",
-  ACL = ""
+  ACL = "",
+  cacheAge = "300"
 ) => {
   // Upload file to bucket
   try {
@@ -39,6 +40,7 @@ const uploadToS3 = async (
         Body: fileBody,
         ContentType: fileType,
         ContentEncoding: encoding,
+        CacheControl: `max-age=${cacheAge}`,
         ACL: ACL,
       })
     );

--- a/deploy/upload-build.js
+++ b/deploy/upload-build.js
@@ -4,7 +4,7 @@ const path = require("path");
 
 const bundleName = "photos_bundle";
 
-const uploadBuild = async (file, encoding = "") => {
+const uploadBuild = async (file, encoding = "", cacheAge = "300") => {
   await s3.createBucket();
   const buildFile = fs.createReadStream(file);
   buildFile.on("error", (err) => {
@@ -17,15 +17,26 @@ const uploadBuild = async (file, encoding = "") => {
     buildFile,
     "text/javascript",
     encoding,
-    "public-read"
+    "public-read",
+    cacheAge
   );
 };
 
 const run = async () => {
-  await uploadBuild(path.join(__dirname, `../public/${bundleName}.js`));
+  await uploadBuild(
+    path.join(__dirname, `../public/${bundleName}.js`),
+    "",
+    "31536000"
+  );
   await uploadBuild(
     path.join(__dirname, `../public/${bundleName}.js.gz`),
-    "gzip"
+    "gzip",
+    "31536000"
+  );
+  await uploadBuild(
+    path.join(__dirname, `../public/${bundleName}.js.br`),
+    "br",
+    "31536000"
   );
   await uploadBuild(path.join(__dirname, `../public/299.${bundleName}.js`));
   await uploadBuild(path.join(__dirname, `../public/344.${bundleName}.js`));


### PR DESCRIPTION
Added cache control property to AWS putObject instance and refactored functions to set cache age. Added brotli bundle to deployment function to further reduce bundle size in production.